### PR TITLE
Remove uses of firstname, lastname and full_name from Solidus Gateway

### DIFF
--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -176,8 +176,8 @@ module Spree
       def generate_address_hash(address)
         return {} if address.nil?
         {
-          first_name: address.firstname,
-          last_name: address.lastname,
+          first_name: Spree::Address::Name.new(address).first_name,
+          last_name: Spree::Address::Name.new(address).last_name,
           address1: address.address1,
           address2: address.address2,
           city: address.city,

--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -49,8 +49,8 @@ module Spree
 
       def verify_creditcard_name!(creditcard)
         bill_address = creditcard.payments.first.order.bill_address
-        creditcard.first_name = bill_address.firstname unless creditcard.first_name?
-        creditcard.last_name = bill_address.lastname   unless creditcard.last_name?
+        creditcard.first_name = Spree::Address::Name.new(bill_address).first_name unless creditcard.first_name?
+        creditcard.last_name = Spree::Address::Name.new(bill_address).last_name unless creditcard.last_name?
       end
 
       def options_for_create_customer_profile(creditcard, gateway_options)
@@ -58,7 +58,7 @@ module Spree
         address = order.bill_address
         { :email=>order.email,
           :billing_address=>
-          { :name=>address.full_name,
+          { :name=>address.name,
             :phone=>address.phone,
             :address1=>address.address1,
             :address2=>address.address2,

--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -161,8 +161,8 @@ module Spree
         if p.order.bill_address
           bill_addr = p.order.bill_address
 
-          o[:first_name] = bill_addr.firstname
-          o[:last_name] = bill_addr.lastname
+          o[:first_name] = Spree::Address::Name.new(bill_addr).first_name
+          o[:last_name] = Spree::Address::Name.new(bill_addr).last_name
 
           o[:billing_address] = {
             address1: bill_addr.address1,

--- a/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
@@ -68,7 +68,7 @@
 <%- if @order.has_checkout_step?('address') && @order.bill_address.present?-%>
   <script>
     Spree.stripeAdditionalInfo = {
-      name: "<%= @order.bill_address.full_name %>",
+      name: "<%= @order.bill_address.name %>",
       address_line1: "<%= @order.bill_address.address1 %>",
       address_line2: "<%= @order.bill_address.address2 %>",
       address_city: "<%= @order.bill_address.city %>",

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -18,8 +18,7 @@ describe Spree::Gateway::BraintreeGateway do
       country = create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840)
       state   = create(:state, name: 'Maryland', abbr: 'MD', country: country)
       address = create(:address,
-        firstname: 'John',
-        lastname:  'Doe',
+        name: 'John Doe',
         address1:  '1234 My Street',
         address2:  'Apt 1',
         city:      'Washington DC',
@@ -51,8 +50,7 @@ describe Spree::Gateway::BraintreeGateway do
       country = create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840)
       state   = create(:state, name: 'Maryland', abbr: 'MD', country: country)
       address = create(:address,
-        firstname: 'John',
-        lastname:  'Doe',
+        name: 'John Doe',
         address1:  '1234 My Street',
         address2:  'Apt 1',
         city:      'Washington DC',
@@ -98,8 +96,7 @@ describe Spree::Gateway::BraintreeGateway do
       country = create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840)
       state   = create(:state, name: 'Maryland', abbr: 'MD', country: country)
       address = create(:address,
-        firstname: 'John',
-        lastname:  'Doe',
+        name: 'John Doe',
         address1:  '1234 My Street',
         address2:  'Apt 1',
         city:      'Washington DC',

--- a/spec/models/gateway/pin_gateway_spec.rb
+++ b/spec/models/gateway/pin_gateway_spec.rb
@@ -11,8 +11,7 @@ describe Spree::Gateway::PinGateway do
     country = create(:country, name: 'Australia', iso_name: 'Australia', iso3: 'AUS', iso: 'AU', numcode: 61)
     state   = create(:state, name: 'Victoria', abbr: 'VIC', country: country)
     address = create(:address,
-      firstname: 'Ronald C',
-      lastname:  'Robot',
+      name: 'Ronald C Robot',
       address1:  '1234 My Street',
       address2:  'Apt 1',
       city:      'Melbourne',

--- a/spec/models/gateway/usa_epay_spec.rb
+++ b/spec/models/gateway/usa_epay_spec.rb
@@ -10,8 +10,7 @@ describe Spree::Gateway::UsaEpay do
     country = create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840)
     state = create(:state, name: 'Maryland', abbr: 'MD', country: country)
     address = create(:address,
-      firstname: 'John',
-      lastname:  'Doe',
+      name: 'John Doe',
       address1:  '1234 My Street',
       address2:  'Apt 1',
       city:      'Washington DC',


### PR DESCRIPTION
This is required to support Solidus 3